### PR TITLE
Downgrade cartopy

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,4 +1,4 @@
-cartopy==0.21.1
+cartopy==0.21.0   # DO NOT UPGRADE THIS! 0.21.1 creates a massively convoluted segmentation fault in py3.8
 cdo==2.0.3
 gh==2.25.1
 myproxy==6.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ requests==2.31.0
 ruptures==1.1.8
 scikit-learn==1.3.0
 scipy==1.10.1
-shapely==1.8.5     # Upgrading to higher breaks cartopy
+# shapely==1.8.5     # Upgrading to higher breaks cartopy
 tornado==6.3.2
 tqdm==4.65.0
 treelib==1.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ requests==2.31.0
 ruptures==1.1.8
 scikit-learn==1.3.0
 scipy==1.10.1
-shapely==2.0.1
+shapely==1.8.5     # Upgrading to higher breaks cartopy
 tornado==6.3.2
 tqdm==4.65.0
 treelib==1.6.4


### PR DESCRIPTION
# Fix cartopy to lower level to support surf builds
I haven't been able to pin down why tests fail on the Surf cluster, but cartopy=0.21.1 fails in a rather apocalyptic manner:
```python
(py38) aangevaare@surfclimalarge:~/software/optim_esm_tools$ pytest -vs test/test_region_finding.py -k test_local_history
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.8.16, pytest-7.4.0, pluggy-1.0.0 -- /home/aangevaare/miniconda3/envs/py38/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/aangevaare/software/optim_esm_tools/.hypothesis/examples')
rootdir: /home/aangevaare/software/optim_esm_tools
plugins: hypothesis-6.80.1, anyio-3.7.1
collected 8 items / 7 deselected / 1 selected

test/test_region_finding.py::Work::test_local_history
--> The keys in the returned dictionary of datasets are constructed as follows:
        'activity_id.institution_id.source_id.experiment_id.table_id.grid_label'
 |████████████████████████████████████████████████████████████████████████████████████████████████████| 100.00% [1/1 00:00<00:00]
--> The keys in the returned dictionary of datasets are constructed as follows:
        'activity_id.institution_id.source_id.experiment_id.table_id.grid_label'
already file at /data/volume_2/synda/data/CMIP6/ScenarioMIP/CCCma/CanESM5/ssp585/r3i1p2f1/Amon/tas/gn/v20190429/test.nc:00<00:00]
File at /data/volume_2/synda/data/CMIP6/ScenarioMIP/CCCma/CanESM5/ssp585/r3i1p2f1/AYear/tas/gn/v20190429/test_merged.nc already exists
Fatal Python error: Segmentation fault

Thread 0x00007f4e4d4a4700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/concurrent/futures/thread.py", line 78 in _worker
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f4e585bc700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/concurrent/futures/thread.py", line 78 in _worker
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f4e5973c700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/concurrent/futures/thread.py", line 78 in _worker
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f4e5a03c700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/concurrent/futures/thread.py", line 78 in _worker
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f4e5a8bc700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/concurrent/futures/thread.py", line 78 in _worker
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f4e5b23c700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/concurrent/futures/thread.py", line 78 in _worker
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f4e6c897700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/concurrent/futures/thread.py", line 78 in _worker
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f4e4ffff700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/concurrent/futures/thread.py", line 78 in _worker
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f4e8ec77700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/concurrent/futures/thread.py", line 78 in _worker
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f4e8c476700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/concurrent/futures/thread.py", line 78 in _worker
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Thread 0x00007f4e89c75700 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/selectors.py", line 468 in select
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/asyncio/base_events.py", line 1823 in _run_once
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/asyncio/base_events.py", line 570 in run_forever
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 870 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/threading.py", line 890 in _bootstrap

Current thread 0x00007f4e9bd4f180 (most recent call first):
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/cartopy/crs.py", line 827 in _project_linear_ring
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/cartopy/crs.py", line 951 in _project_polygon
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/cartopy/crs.py", line 808 in project_geometry
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/cartopy/mpl/geoaxes.py", line 190 in transform_path_non_affine
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/matplotlib/transforms.py", line 2439 in transform_path_non_affine
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/matplotlib/collections.py", line 266 in <listcomp>
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/matplotlib/collections.py", line 266 in get_datalim
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/cartopy/mpl/geoaxes.py", line 2015 in pcolor
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/cartopy/mpl/geoaxes.py", line 318 in wrapper
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/cartopy/mpl/geoaxes.py", line 1970 in _wrap_quadmesh
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/cartopy/mpl/geoaxes.py", line 1787 in pcolormesh
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/cartopy/mpl/geoaxes.py", line 318 in wrapper
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/xarray/plot/dataarray_plot.py", line 2340 in pcolormesh
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/xarray/plot/dataarray_plot.py", line 1613 in newplotfunc
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/xarray/plot/dataarray_plot.py", line 312 in plot
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/xarray/plot/accessor.py", line 46 in __call__
  File "/home/aangevaare/software/optim_esm_tools/optim_esm_tools/plotting/map_maker.py", line 182 in plot_i
  File "/home/aangevaare/software/optim_esm_tools/optim_esm_tools/utils.py", line 354 in timed_func
  File "/home/aangevaare/software/optim_esm_tools/optim_esm_tools/plotting/map_maker.py", line 145 in plot_selected
  File "/home/aangevaare/software/optim_esm_tools/optim_esm_tools/analyze/region_finding.py", line 681 in _plot_basic_map
  File "/home/aangevaare/software/optim_esm_tools/optim_esm_tools/analyze/region_finding.py", line 83 in timed_func
  File "/home/aangevaare/software/optim_esm_tools/optim_esm_tools/analyze/region_finding.py", line 158 in plot_basic_map
  File "/home/aangevaare/software/optim_esm_tools/optim_esm_tools/analyze/region_finding.py", line 61 in plt_func
  File "/home/aangevaare/software/optim_esm_tools/optim_esm_tools/analyze/region_finding.py", line 149 in workflow
  File "/home/aangevaare/software/optim_esm_tools/optim_esm_tools/analyze/region_finding.py", line 83 in timed_func
  File "/home/aangevaare/software/optim_esm_tools/test/test_region_finding.py", line 53 in test_max_region
  File "/home/aangevaare/software/optim_esm_tools/test/test_region_finding.py", line 75 in test_local_history
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/unittest/case.py", line 633 in _callTestMethod
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/unittest/case.py", line 676 in run
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/unittest/case.py", line 736 in __call__
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/unittest.py", line 333 in runtest
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 169 in pytest_runtest_call
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 262 in <lambda>
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 341 in from_call
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 261 in call_runtest_hook
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 222 in call_and_report
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 133 in runtestprotocol
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/runner.py", line 114 in pytest_runtest_protocol
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/main.py", line 349 in pytest_runtestloop
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/main.py", line 324 in _main
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/main.py", line 270 in wrap_session
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/main.py", line 317 in pytest_cmdline_main
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/config/__init__.py", line 166 in main
  File "/home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/config/__init__.py", line 189 in console_main
  File "/home/aangevaare/miniconda3/envs/py38/bin/pytest", line 8 in <module>
Segmentation fault (core dumped)
```

It cost me quite some time pinpointing this to some issue with cartopy (as the github tests work completely fine).


```python
(py38) aangevaare@surfclimalarge:~$ python3 -c "import optim_esm_tools; optim_esm_tools.utils.print_versions('optim_esm_tools cartopy shapely numpy matplotlib xarray'.split())"
Host surfclimalarge
         module     version                                                                         path                     git
         python      3.8.16                            /home/aangevaare/miniconda3/envs/py38/bin/python3                    None
optim_esm_tools       0.4.0                    /home/aangevaare/software/optim_esm_tools/optim_esm_tools branch:master | 1d99a3d
        cartopy      0.21.0    /home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/cartopy                    None
        shapely 1.8.5.post1    /home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/shapely                    None
          numpy      1.24.4      /home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/numpy                    None
     matplotlib        None /home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/matplotlib                    None
         xarray    2023.1.0     /home/aangevaare/miniconda3/envs/py38/lib/python3.8/site-packages/xarray                    None
``` 