### PR TITLE
Drop `r-base` requirement

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -2,5 +2,4 @@
 cartopy==0.21.0
 cdo==2.0.3
 gh==2.25.1
-r-base==4.3.1
 r-essentials==4.3


### PR DESCRIPTION
it's already required by r-essentials