### PR TITLE
Move cartopy to pip

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,5 +1,3 @@
-# DO NOT UPGRADE cartopy! 0.21.1 creates a massively convoluted segmentation fault in py3.8
-cartopy==0.21.0
 cdo==2.0.3
 gh==2.25.1
 r-base==4.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 aiohttp==3.8.5
+cartopy==0.22.0
 cdo==1.5.7
 cftime==1.6.2
 coverage==6.5.0
 coveralls==3.3.1
-cartopy==0.22.0
 dask==2023.5.0
 diptest==0.5.2
 gcsfs==2023.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cdo==1.5.7
 cftime==1.6.2
 coverage==6.5.0
 coveralls==3.3.1
+cartopy==0.22.0
 dask==2023.5.0
 diptest==0.5.2
 gcsfs==2023.6.0


### PR DESCRIPTION
After https://github.com/SciTools/cartopy/pull/2197, we should be able to pip install 🎉 ! Let's drop conda 😄 