### PR TITLE
anyio to ignored dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,7 @@ updates:
       - dependency-name: "jupyterlab-pygments"
       - dependency-name: "jupyterlab-widgets"
       - dependency-name: "tornado"
+      - dependency-name: "anyio"
     groups:
       fs-deps:
         patterns:


### PR DESCRIPTION
it's one of the jupiter dependencies, since we don't update those, also ignore `anyio`