### PR TITLE
Restorte testing, use conda, pin shapely to 1.8.5.post1

### DIFF
--- a/.github/workflows/test_create_env.yml
+++ b/.github/workflows/test_create_env.yml
@@ -34,8 +34,8 @@ jobs:
           # Conda takes a long time, only do it when the PR is merged
           - installer: conda
             os: ubuntu-latest
-          - installer: conda
-            shouldSkipConda: true
+          # - installer: conda
+            # shouldSkipConda: true
 
           # This one oddly takes a long time since #75?!
           - installer: conda

--- a/.github/workflows/test_create_env.yml
+++ b/.github/workflows/test_create_env.yml
@@ -106,6 +106,7 @@ jobs:
             #             bash ../oet/.github/scripts/download_example_data.sh
             bash ../oet/.github/scripts/install_tex.sh
             pip install -e ../oet
+            python -c "import optim_esm_tools as oet; oet.utils.print_versions(); print('import cartopy'); import cartopy; print('setup map'); oet.plotting.plot.setup_map(); print('done'); oet.utils.print_versions('shapely cartopy urllib'.split())"
             pytest -vx ../oet
       - name: List packages
         run:

--- a/.github/workflows/test_create_env.yml
+++ b/.github/workflows/test_create_env.yml
@@ -47,15 +47,15 @@ jobs:
           - install: full
             python-version: '3.10'
 
-          # Py>3.8 only on ubuntu latest
-          - os: ubuntu-20.04
-            python-version: '3.9'
-          - os: ubuntu-20.04
-            python-version: '3.10'
+          # # Py>3.8 only on ubuntu latest
+          # - os: ubuntu-20.04
+          #   python-version: '3.9'
+          # - os: ubuntu-20.04
+          #   python-version: '3.10'
 
-          # Testing optim_esm_tools should be light weight
-          - install: optim_tools
-            installer: conda
+          # # Testing optim_esm_tools should be light weight
+          # - install: optim_tools
+          #   installer: conda
 
     defaults:
       run:

--- a/.github/workflows/test_create_env.yml
+++ b/.github/workflows/test_create_env.yml
@@ -35,7 +35,7 @@ jobs:
           - installer: conda
             os: ubuntu-latest
           # - installer: conda
-            # shouldSkipConda: true
+          #   shouldSkipConda: true
 
           # This one oddly takes a long time since #75?!
           - installer: conda

--- a/.github/workflows/test_create_env.yml
+++ b/.github/workflows/test_create_env.yml
@@ -107,7 +107,7 @@ jobs:
             bash ../oet/.github/scripts/install_tex.sh
             pip install -e ../oet
             python -c "import optim_esm_tools as oet; oet.utils.print_versions(); print('import cartopy'); import cartopy; print('setup map'); oet.plotting.plot.setup_map(); print('done'); oet.utils.print_versions('shapely cartopy urllib'.split())"
-            pytest -vx ../oet
+            pytest -vx ../oet --durations 0
       - name: List packages
         run:
            |

--- a/requirements.txt
+++ b/requirements.txt
@@ -196,7 +196,7 @@ traitlets==5.14.3
 treelib==1.7.0
 tzlocal==5.2
 uri-template==1.3.0
-urllib3==2.2.2
+urllib3==2.2.1
 wcwidth==0.2.13
 webcolors==24.6.0
 webencodings==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -178,7 +178,7 @@ ruptures==1.1.9
 scikit-learn==1.3.2
 scipy==1.10.1
 Send2Trash==1.8.3
-shapely=1.8.5
+shapely==1.8.5
 shutilwhich==1.1.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -178,6 +178,7 @@ ruptures==1.1.9
 scikit-learn==1.3.2
 scipy==1.10.1
 Send2Trash==1.8.3
+shapely=1.8.5
 shutilwhich==1.1.0
 smmap==5.0.1
 sniffio==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -178,7 +178,7 @@ ruptures==1.1.9
 scikit-learn==1.3.2
 scipy==1.10.1
 Send2Trash==1.8.3
-shapely==1.8.5
+shapely==1.8.5.post1
 shutilwhich==1.1.0
 smmap==5.0.1
 sniffio==1.3.1


### PR DESCRIPTION
Tests were failing for a while now. In this PR:

- Pin shapely to `1.8.5.post1` -> this is most likely the fix
- Print the versions of some essential tools -> This might be a fix as some files are downloaded and I that might have not worked during the pytest phase
- Restart conda -> for some reason it's just as fast as mamba, which is a bit of a surprise to me