### PR TITLE
Create miniforge workflow

### DIFF
--- a/.github/workflows/test_create_env.yml
+++ b/.github/workflows/test_create_env.yml
@@ -24,7 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         install: [optim_tools, fast]
-        installer: [mamba, miniforge, conda]
+        # installer: [mamba, miniforge, conda]
+        installer: [miniforge]
         os: [ubuntu-latest, ubuntu-20.04]
         python-version: ['3.8', '3.9', '3.10']
         shouldSkipConda:

--- a/.github/workflows/test_create_env.yml
+++ b/.github/workflows/test_create_env.yml
@@ -24,8 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         install: [optim_tools, fast]
-        # installer: [mamba, miniforge, conda]
-        installer: [miniforge]
+        installer: [mamba, miniforge, conda]
         os: [ubuntu-latest, ubuntu-20.04]
         python-version: ['3.8', '3.9', '3.10']
         shouldSkipConda:

--- a/.github/workflows/test_create_env.yml
+++ b/.github/workflows/test_create_env.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        install: [optim_tools, full, fast]
-        installer: [mamba, conda]
+        install: [optim_tools, fast]
+        installer: [mamba, miniforge, conda]
         os: [ubuntu-latest, ubuntu-20.04]
         python-version: ['3.8', '3.9', '3.10']
         shouldSkipConda:
@@ -34,28 +34,10 @@ jobs:
           # Conda takes a long time, only do it when the PR is merged
           - installer: conda
             os: ubuntu-latest
-          # - installer: conda
-          #   shouldSkipConda: true
 
           # This one oddly takes a long time since #75?!
           - installer: conda
             install: fast
-
-          # Full install only for py3.8 because of synda requirement
-          - install: full
-            python-version: '3.9'
-          - install: full
-            python-version: '3.10'
-
-          # # Py>3.8 only on ubuntu latest
-          # - os: ubuntu-20.04
-          #   python-version: '3.9'
-          # - os: ubuntu-20.04
-          #   python-version: '3.10'
-
-          # # Testing optim_esm_tools should be light weight
-          # - install: optim_tools
-          #   installer: conda
 
     defaults:
       run:
@@ -75,13 +57,23 @@ jobs:
             activate-environment: 'synda'
             mamba-version: '*'
       - uses: conda-incubator/setup-miniconda@v3
+        if: matrix.installer == 'miniforege'
+        with:
+            installer-url: https://github.com/conda-forge/miniforge/releases/download/24.9.2-0/Miniforge3-24.9.2-0-Linux-x86_64.sh
+            allow-softlinks: true
+            show-channel-urls: true
+            use-only-tar-bz2: true
+            auto-update-conda: true
+            python-version: ${{ matrix.python-version }}
+            activate-environment: 'synda'
+      - uses: conda-incubator/setup-miniconda@v3
         if: matrix.installer == 'conda'
         with:
             auto-update-conda: true
             python-version: ${{ matrix.python-version }}
             activate-environment: 'synda'
       - name: run install
-        if: matrix.install == 'full' || matrix.install == 'optim_tools'
+        if: matrix.install == 'optim_tools'
         run:
           |
             bash install_software.sh --installer $installer
@@ -95,15 +87,10 @@ jobs:
           |
           pytest test
       - name: run optim_tools-tests
-#         env:
-#           OPEN_ID: ${{ secrets.OPEN_ID }}
-#           OPEN_ID_KEY: ${{ secrets.OPEN_ID_KEY }}
         if: matrix.install == 'optim_tools'
         run:
             |
             git clone https://github.com/JoranAngevaare/optim_esm_tools.git ../oet
-            #             bash ../oet/.github/scripts/write_synda_cridentials.sh
-            #             bash ../oet/.github/scripts/download_example_data.sh
             bash ../oet/.github/scripts/install_tex.sh
             pip install -e ../oet
             python -c "import optim_esm_tools as oet; oet.utils.print_versions(); print('import cartopy'); import cartopy; print('setup map'); oet.plotting.plot.setup_map(); print('done'); oet.utils.print_versions('shapely cartopy urllib'.split())"

--- a/.github/workflows/test_create_env.yml
+++ b/.github/workflows/test_create_env.yml
@@ -57,7 +57,7 @@ jobs:
             activate-environment: 'synda'
             mamba-version: '*'
       - uses: conda-incubator/setup-miniconda@v3
-        if: matrix.installer == 'miniforege'
+        if: matrix.installer == 'miniforge'
         with:
             installer-url: https://github.com/conda-forge/miniforge/releases/download/24.9.2-0/Miniforge3-24.9.2-0-Linux-x86_64.sh
             allow-softlinks: true

--- a/README.md
+++ b/README.md
@@ -1,47 +1,28 @@
 # optim_esm_base
-Base for OptimESM software
+Base for OptimESM software.
+Most of the time, you can run the partial install.
+A much more convoluted installation is the "full" install which utilizes quite a few deprecated packages.
 
-# Full Installation (on linux)
+There are three installation methods:
+ - miniforge
+ - conda (sometimes paid, depending on the institute)
+ - mamba (deprecated per July 2024)
 
-```bash
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh .
-bash Miniconda3-latest-Linux-x86_64.sh
+As mamba and conda have their downsides, we default to miniforge (since December 2024).
 
-git clone https://github.com/JoranAngevaare/optim_esm_base
-cd optim_esm_base
-conda install python=3.8.19
-bash create py38
-export SOME_SYNDA_PATH=../
-conda activate py38
-bash install_software.sh --installer conda --synda_dir SOME_SYNDA_PATH
-pytest test
-
-bash set_jupy.sh
-```
-This package is the base for `optim_esm_tools` so we also include how to install that
-```
-## Optional optim_esm_tools
-git clone https://github.com/JoranAngevaare/optim_esm_tools.git ../oet
-bash ../oet/.github/scripts/write_synda_cridentials.sh
-bash ../oet/.github/scripts/download_example_data.sh
-bash ../oet/.github/scripts/install_tex.sh
-pip install -e ../oet
-python -c "import optim_esm_tools as oet; oet.utils.print_versions(); print('import cartopy'); import cartopy; print('setup map'); oet.plotting.plot.setup_map(); print('done'); oet.utils.print_versions('shapely cartopy urllib'.split())"
-pytest -vx ../oet --durations 0
-```
 
 # Partial installation (on linux) without `synda`
 
 ```bash
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh .
-bash Miniconda3-latest-Linux-x86_64.sh
+wget https://github.com/conda-forge/miniforge/releases/download/24.9.2-0/Miniforge3-24.9.2-0-Linux-x86_64.sh .
+bash Miniforge3-24.9.2-0-Linux-x86_64.sh
 
 git clone https://github.com/JoranAngevaare/optim_esm_base
 cd optim_esm_base
 conda install python=3.8.19
 bash create py38
 conda activate py38
-bash install_software.sh --installer conda --no_synda
+bash install_software.sh --installer miniforge --no_synda
 pytest test
 
 ## Optional optim_esm_tools
@@ -52,5 +33,35 @@ pip install -e ../oet
 python -c "import optim_esm_tools as oet; oet.utils.print_versions(); print('import cartopy'); import cartopy; print('setup map'); oet.plotting.plot.setup_map(); print('done'); oet.utils.print_versions('shapely cartopy urllib'.split())"
 
 # Check if everything works with this current installation
+pytest -vx ../oet --durations 0
+```
+# Full Installation (on linux)
+
+```bash
+wget https://github.com/conda-forge/miniforge/releases/download/24.9.2-0/Miniforge3-24.9.2-0-Linux-x86_64.sh .
+bash Miniforge3-24.9.2-0-Linux-x86_64.sh
+
+git clone https://github.com/JoranAngevaare/optim_esm_base
+cd optim_esm_base
+conda install python=3.8.19
+bash create py38
+export SOME_SYNDA_PATH=../
+conda activate py38
+bash install_software.sh --installer conda --synda_dir $SOME_SYNDA_PATH
+pytest test
+
+bash set_jupy.sh
+```
+
+This package is the base for `optim_esm_tools` so we also include how to install that
+
+```bash
+## Optional optim_esm_tools
+git clone https://github.com/JoranAngevaare/optim_esm_tools.git ../oet
+bash ../oet/.github/scripts/write_synda_cridentials.sh
+bash ../oet/.github/scripts/download_example_data.sh
+bash ../oet/.github/scripts/install_tex.sh
+pip install -e ../oet
+python -c "import optim_esm_tools as oet; oet.utils.print_versions(); print('import cartopy'); import cartopy; print('setup map'); oet.plotting.plot.setup_map(); print('done'); oet.utils.print_versions('shapely cartopy urllib'.split())"
 pytest -vx ../oet --durations 0
 ```

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,4 +1,4 @@
 # DO NOT UPGRADE cartopy! 0.21.1 creates a massively convoluted segmentation fault in py3.8
 cartopy==0.21.0
 cdo==2.0.3
-r-base==4.4.2
+r-base

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,4 +1,4 @@
 # DO NOT UPGRADE cartopy! 0.21.1 creates a massively convoluted segmentation fault in py3.8
 cartopy==0.21.0
 cdo==2.0.3
-r-base==4.4.2
+r-base==4.2.2

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,5 +1,4 @@
 # DO NOT UPGRADE cartopy! 0.21.1 creates a massively convoluted segmentation fault in py3.8
 cartopy==0.21.0
 cdo==2.0.3
-gh==2.25.1
-r-base==4.2.3
+r-base==4.4.2

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,4 +1,4 @@
 # DO NOT UPGRADE cartopy! 0.21.1 creates a massively convoluted segmentation fault in py3.8
 cartopy==0.21.0
 cdo==2.0.3
-r-base
+r-base==4.4.2

--- a/install_software.sh
+++ b/install_software.sh
@@ -87,10 +87,10 @@ fi
 if [[ $no_cdo == 1 ]];
 then
     echo "Skip CDO install"
-    cat conda_requirements.txt | grep -v "#" | grep -v cdo >> tmp.txt
+    cat conda_requirements.txt | grep -v "#" | grep -v cdo &> tmp.txt
     $installer env config vars set BASE_NO_CDO=1
 else
-    cat conda_requirements.txt | grep -v "#" | grep -v "somethingsomething" >> tmp.txt
+    cat conda_requirements.txt | grep -v "#" | grep -v "somethingsomething" &> tmp.txt
 fi
 
 if [[ "$installer" == 'conda' ]];

--- a/install_software.sh
+++ b/install_software.sh
@@ -40,6 +40,12 @@ set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 installer="${installer:-"mamba"}"
 synda_dir_name="${synda_dir:-"$(pwd)/synda"}"
 
+if [[ $installer == "miniforge" ]];
+then
+    announce "using miniforge (subcommands are calling \"conda\")"
+    installer="conda"
+fi
+
 echo "args are" synda_dir:$synda_dir_name no_synda:$no_synda no_cdo:$no_cdo installer:$installer
 
 function announce {

--- a/install_software.sh
+++ b/install_software.sh
@@ -40,11 +40,7 @@ set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 installer="${installer:-"mamba"}"
 synda_dir_name="${synda_dir:-"$(pwd)/synda"}"
 
-if [[ $installer == "miniforge" ]];
-then
-    announce "using miniforge (subcommands are calling \"conda\")"
-    installer="conda"
-fi
+
 
 echo "args are" synda_dir:$synda_dir_name no_synda:$no_synda no_cdo:$no_cdo installer:$installer
 
@@ -55,6 +51,12 @@ function announce {
     printf "## $1\n"
     echo
 }
+
+if [[ $installer == "miniforge" ]];
+then
+    announce "using miniforge (subcommands are calling \"conda\")"
+    installer="conda"
+fi
 
 if [[ $no_synda == 1 ]];
 then

--- a/install_software.sh
+++ b/install_software.sh
@@ -52,11 +52,14 @@ function announce {
     echo
 }
 
+method=$installer
 if [[ $installer == "miniforge" ]];
 then
     announce "using miniforge (subcommands are calling \"conda\")"
     installer="conda"
 fi
+announce "using installler $installer and method $method"
+
 
 if [[ $no_synda == 1 ]];
 then
@@ -93,7 +96,7 @@ else
     cat conda_requirements.txt | grep -v "#" | grep -v "somethingsomething" &> tmp.txt
 fi
 
-if [[ "$installer" == 'conda' ]];
+if [[ "$method" == 'conda' ]];
 then
     announce "install from conda forge:\n$(cat tmp.txt)"
     conda install  -c conda-forge --file tmp.txt --yes -q

--- a/install_software.sh
+++ b/install_software.sh
@@ -37,7 +37,7 @@ done
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
 
-installer="${installer:-"mamba"}"
+installer="${installer:-"miniforge"}"
 synda_dir_name="${synda_dir:-"$(pwd)/synda"}"
 
 

--- a/install_software.sh
+++ b/install_software.sh
@@ -52,13 +52,15 @@ function announce {
     echo
 }
 
+# This is a bit convoluted, but we call "conda" for miniforge installations. Nevertheless, we need to keep
+# track of that we are doing a miniforge build since miniforge (at 2024/12/03) doesn't parse the --file option
+# well so we need a trick (see comment below).
 method=$installer
 if [[ $installer == "miniforge" ]];
 then
-    announce "using miniforge (subcommands are calling \"conda\")"
+    announce "using $installer (subcommands are calling \"conda\")"
     installer="conda"
 fi
-announce "using installler $installer and method $method"
 
 
 if [[ $no_synda == 1 ]];
@@ -101,7 +103,7 @@ then
     announce "install from conda forge:\n$(cat tmp.txt)"
     conda install  -c conda-forge --file tmp.txt --yes -q
 else
-    # Todo, this is akward, I think mamba does not parse --file well
+    # Todo, this is akward, I think mamba/miniforge does not parse --file well
     # See https://github.com/JoranAngevaare/optim_esm_base/pull/54
     announce "install from conda forge:\n$(cat tmp.txt)"
     for dep in $(cat tmp.txt);


### PR DESCRIPTION
# Create miniforege workflow
in this PR we add a third method (miniforge) to install the software, in addition to conda (paid for some institures) and mamba (deprecated since July).

