### PR TITLE
Disable mamba and conda

### DIFF
--- a/.github/workflows/test_create_env.yml
+++ b/.github/workflows/test_create_env.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         install: [optim_tools, fast]
-        installer: [mamba, miniforge, conda]
+        installer: [miniforge]
         os: [ubuntu-latest, ubuntu-20.04]
         python-version: ['3.8', '3.9', '3.10']
         shouldSkipConda:


### PR DESCRIPTION
Following #659 , only use miniforge for testing.