### PR TITLE
remove the R-depencencies

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -2,4 +2,3 @@
 cartopy==0.21.0
 cdo==2.0.3
 pycairo==1.25.0
-r-base==4.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -179,10 +179,6 @@ requests-oauthlib==2.0.0
 retrying==1.3.4
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
-rpds-py==0.25.1; python_version>="3.9"
-rpds-py==0.20.1; python_version=="3.8"
-rpy-symmetry==0.3.0
-rpy2==3.5.17
 rsa==4.9.1
 ruptures==1.1.9
 scikit-learn==1.6.1; python_version>="3.9"


### PR DESCRIPTION
Since optim-esm-tools v5.0.0 we don't have R as a dependency anymore since we dropped the symmetry test requirement. See https://github.com/JoranAngevaare/optim_esm_tools/pull/245
